### PR TITLE
Removed "Refresh" value

### DIFF
--- a/nagisk.pl
+++ b/nagisk.pl
@@ -545,13 +545,13 @@ if ($asterisk_command_tag eq "channels") {
         if (/Username/) {
             next;
         }
-        if ((/$asterisk_peer_name/) and (/105 Registered/)) {
+        if ((/$asterisk_peer_name/) and (/Registered/)) {
             $return = $STA_OK;
             $output = "Trunk $asterisk_peer_name Registered";
             $found++;
             last;
         }
-        if ((/$asterisk_peer_name/) and (!/105 Registered/)) {
+        if ((/$asterisk_peer_name/) and (!/Registered/)) {
             $return = $STA_CRITICAL;
             $output = "Trunk $asterisk_peer_name Not Registered";
             $found++;


### PR DESCRIPTION
The number `105` was indicating the Refresh-rate which can vary. Therefore we should not statically check for the value `105`
[Additonal reference](https://community.freepbx.org/t/help-needed-with-sip-registration-expiry/14131)